### PR TITLE
Redesign forum ui with shadcnui on vercel

### DIFF
--- a/forum-ui/.gitignore
+++ b/forum-ui/.gitignore
@@ -1,0 +1,11 @@
+.next
+node_modules
+.env*
+dist
+out
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+package-lock.json
+

--- a/forum-ui/README.md
+++ b/forum-ui/README.md
@@ -1,0 +1,32 @@
+Forum UI (shadcn/ui + Next.js)
+
+Redesigned forum using Next.js App Router, Tailwind CSS, and shadcn/ui patterns.
+
+Development
+
+```
+npm install
+npm run dev
+```
+
+Build
+
+```
+npm run build
+npm start
+```
+
+Deploy to Vercel
+
+1. Push this project to GitHub/GitLab.
+2. Create a new Vercel project and import the repo.
+3. Framework preset: Next.js (auto-detected)
+4. Build command: `next build`
+5. Output: `.next`
+6. Optional: set `NODE_VERSION` and `NEXT_TELEMETRY_DISABLED=1`.
+
+Notes
+- Dark mode via `next-themes` (class strategy)
+- Tailwind tokens follow shadcn/ui conventions
+- Example pages: 首頁、看板、最新、文章詳情、發文、基本用戶頁
+

--- a/forum-ui/next-env.d.ts
+++ b/forum-ui/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/forum-ui/next.config.mjs
+++ b/forum-ui/next.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+export default nextConfig;
+

--- a/forum-ui/package.json
+++ b/forum-ui/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "forum-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "postinstall": "tailwindcss -v >/dev/null 2>&1 || echo 'Tailwind not installed yet'"
+  },
+  "dependencies": {
+    "@radix-ui/react-avatar": "^1.0.4",
+    "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-dropdown-menu": "^2.0.6",
+    "@radix-ui/react-navigation-menu": "^1.1.4",
+    "@radix-ui/react-separator": "^1.0.3",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.468.0",
+    "next": "^14.2.5",
+    "next-themes": "^0.3.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "tailwind-merge": "^2.5.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.5",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.3",
+    "tailwindcss-animate": "^1.0.7",
+    "@tailwindcss/typography": "^0.5.15",
+    "typescript": "^5.4.5"
+  }
+}
+

--- a/forum-ui/postcss.config.mjs
+++ b/forum-ui/postcss.config.mjs
@@ -1,0 +1,7 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+

--- a/forum-ui/src/app/(user)/notifications/page.tsx
+++ b/forum-ui/src/app/(user)/notifications/page.tsx
@@ -1,0 +1,18 @@
+import { AppShell } from "@/components/app-shell";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function NotificationsPage() {
+  return (
+    <AppShell>
+      <Card>
+        <CardHeader>
+          <CardTitle>通知</CardTitle>
+        </CardHeader>
+        <CardContent>
+          即將推出…
+        </CardContent>
+      </Card>
+    </AppShell>
+  );
+}
+

--- a/forum-ui/src/app/(user)/profile/page.tsx
+++ b/forum-ui/src/app/(user)/profile/page.tsx
@@ -1,0 +1,18 @@
+import { AppShell } from "@/components/app-shell";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function ProfilePage() {
+  return (
+    <AppShell>
+      <Card>
+        <CardHeader>
+          <CardTitle>個人檔案</CardTitle>
+        </CardHeader>
+        <CardContent>
+          即將推出…
+        </CardContent>
+      </Card>
+    </AppShell>
+  );
+}
+

--- a/forum-ui/src/app/(user)/settings/page.tsx
+++ b/forum-ui/src/app/(user)/settings/page.tsx
@@ -1,0 +1,18 @@
+import { AppShell } from "@/components/app-shell";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function SettingsPage() {
+  return (
+    <AppShell>
+      <Card>
+        <CardHeader>
+          <CardTitle>設定</CardTitle>
+        </CardHeader>
+        <CardContent>
+          即將推出…
+        </CardContent>
+      </Card>
+    </AppShell>
+  );
+}
+

--- a/forum-ui/src/app/categories/page.tsx
+++ b/forum-ui/src/app/categories/page.tsx
@@ -1,0 +1,24 @@
+import { AppShell } from "@/components/app-shell";
+import Link from "next/link";
+
+const categories = [
+  { slug: "general", name: "閒聊" },
+  { slug: "tech", name: "技術" },
+  { slug: "announcements", name: "公告" }
+];
+
+export default function CategoriesPage() {
+  return (
+    <AppShell>
+      <h1 className="text-2xl font-semibold mb-4">看板</h1>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {categories.map(c => (
+          <Link key={c.slug} href={`/categories/${c.slug}`} className="rounded-lg border p-6 hover:bg-accent">
+            {c.name}
+          </Link>
+        ))}
+      </div>
+    </AppShell>
+  );
+}
+

--- a/forum-ui/src/app/globals.css
+++ b/forum-ui/src/app/globals.css
@@ -1,0 +1,71 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 84% 4.9%;
+
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 84% 4.9%;
+
+  --popover: 0 0% 100%;
+  --popover-foreground: 222.2 84% 4.9%;
+
+  --primary: 221.2 83.2% 53.3%;
+  --primary-foreground: 210 40% 98%;
+
+  --secondary: 210 40% 96.1%;
+  --secondary-foreground: 222.2 47.4% 11.2%;
+
+  --muted: 210 40% 96.1%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+
+  --accent: 210 40% 96.1%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 40% 98%;
+
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --ring: 221.2 83.2% 53.3%;
+
+  --radius: 0.5rem;
+}
+
+.dark {
+  --background: 222.2 84% 4.9%;
+  --foreground: 210 40% 98%;
+
+  --card: 222.2 84% 4.9%;
+  --card-foreground: 210 40% 98%;
+
+  --popover: 222.2 84% 4.9%;
+  --popover-foreground: 210 40% 98%;
+
+  --primary: 217.2 91.2% 59.8%;
+  --primary-foreground: 222.2 47.4% 11.2%;
+
+  --secondary: 217.2 32.6% 17.5%;
+  --secondary-foreground: 210 40% 98%;
+
+  --muted: 217.2 32.6% 17.5%;
+  --muted-foreground: 215 20.2% 65.1%;
+
+  --accent: 217.2 32.6% 17.5%;
+  --accent-foreground: 210 40% 98%;
+
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 210 40% 98%;
+
+  --border: 217.2 32.6% 17.5%;
+  --input: 217.2 32.6% 17.5%;
+  --ring: 224.3 76.3% 48%;
+}
+
+@layer base {
+  * { @apply border-border; }
+  body { @apply bg-background text-foreground; }
+}
+

--- a/forum-ui/src/app/layout.tsx
+++ b/forum-ui/src/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { ThemeProvider } from "@/components/theme-provider";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Forum UI",
+  description: "Redesigned forum using shadcn/ui"
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="zh-Hant" suppressHydrationWarning>
+      <body>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          {children}
+        </ThemeProvider>
+      </body>
+    </html>
+  );
+}
+

--- a/forum-ui/src/app/loading.tsx
+++ b/forum-ui/src/app/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="space-y-3">
+      <Skeleton className="h-8 w-64" />
+      <Skeleton className="h-24 w-full" />
+      <Skeleton className="h-24 w-full" />
+      <Skeleton className="h-24 w-full" />
+    </div>
+  );
+}
+

--- a/forum-ui/src/app/page.tsx
+++ b/forum-ui/src/app/page.tsx
@@ -1,0 +1,14 @@
+import { AppShell } from "@/components/app-shell";
+import { ThreadList } from "@/components/thread-list";
+
+export default function HomePage() {
+  return (
+    <AppShell>
+      <div className="space-y-6">
+        <h1 className="text-2xl font-semibold tracking-tight">熱門討論</h1>
+        <ThreadList />
+      </div>
+    </AppShell>
+  );
+}
+

--- a/forum-ui/src/app/threads/[id]/page.tsx
+++ b/forum-ui/src/app/threads/[id]/page.tsx
@@ -1,0 +1,22 @@
+import { AppShell } from "@/components/app-shell";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function ThreadDetailPage({ params }: { params: { id: string } }) {
+  const { id } = params;
+
+  return (
+    <AppShell>
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>討論串 #{id}</CardTitle>
+          </CardHeader>
+          <CardContent className="prose dark:prose-invert max-w-none">
+            <p>這裡是文章內容。使用 shadcn/ui 重新設計的版面。</p>
+          </CardContent>
+        </Card>
+      </div>
+    </AppShell>
+  );
+}
+

--- a/forum-ui/src/app/threads/new/page.tsx
+++ b/forum-ui/src/app/threads/new/page.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { AppShell } from "@/components/app-shell";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useState } from "react";
+
+export default function NewThreadPage() {
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+
+  return (
+    <AppShell>
+      <Card>
+        <CardHeader>
+          <CardTitle>發表新文章</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Input value={title} onChange={e => setTitle(e.target.value)} placeholder="標題" />
+          <textarea className="min-h-[240px] w-full rounded-md border border-input bg-background p-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" placeholder="內容" value={content} onChange={e => setContent(e.target.value)} />
+          <div className="flex justify-end">
+            <Button disabled={!title.trim()}>發佈</Button>
+          </div>
+        </CardContent>
+      </Card>
+    </AppShell>
+  );
+}
+

--- a/forum-ui/src/app/threads/page.tsx
+++ b/forum-ui/src/app/threads/page.tsx
@@ -1,0 +1,14 @@
+import { AppShell } from "@/components/app-shell";
+import { ThreadList } from "@/components/thread-list";
+
+export default function ThreadsPage() {
+  return (
+    <AppShell>
+      <div className="space-y-6">
+        <h1 className="text-2xl font-semibold tracking-tight">最新文章</h1>
+        <ThreadList />
+      </div>
+    </AppShell>
+  );
+}
+

--- a/forum-ui/src/components/app-shell.tsx
+++ b/forum-ui/src/components/app-shell.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Search, Bell, Sun, Moon, Plus } from "lucide-react";
+import { useTheme } from "next-themes";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { cn } from "@/lib/utils";
+
+export function AppShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const { theme, setTheme } = useTheme();
+
+  const nav = [
+    { href: "/", label: "首頁" },
+    { href: "/categories", label: "看板" },
+    { href: "/threads", label: "最新" }
+  ];
+
+  return (
+    <div className="min-h-screen">
+      <header className="sticky top-0 z-40 w-full border-b bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <div className="container flex h-16 items-center gap-4">
+          <Link href="/" className="font-semibold">Forum</Link>
+          <nav className="hidden md:flex items-center gap-2 text-sm">
+            {nav.map(item => (
+              <Link key={item.href} href={item.href} className={cn("px-3 py-2 rounded-md hover:bg-accent", pathname === item.href && "bg-accent text-accent-foreground")}>{item.label}</Link>
+            ))}
+          </nav>
+          <div className="ml-auto flex items-center gap-2">
+            <div className="relative w-64 hidden sm:block">
+              <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input className="pl-8" placeholder="搜尋…" />
+            </div>
+            <Button variant="ghost" size="icon" aria-label="notifications"><Bell className="h-5 w-5" /></Button>
+            <Button variant="ghost" size="icon" aria-label="toggle theme" onClick={() => setTheme(theme === "dark" ? "light" : "dark")}>
+              <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+              <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+            </Button>
+            <Avatar>
+              <AvatarFallback>U</AvatarFallback>
+            </Avatar>
+            <Button asChild><Link href="/threads/new"><Plus className="mr-2 h-4 w-4" />發文</Link></Button>
+          </div>
+        </div>
+      </header>
+
+      <main className="container grid grid-cols-1 lg:grid-cols-12 gap-6 py-6">
+        <aside className="hidden lg:block lg:col-span-3">
+          <div className="space-y-1">
+            {nav.map(item => (
+              <Link key={item.href} href={item.href} className={cn("block px-3 py-2 rounded-md hover:bg-accent", pathname === item.href && "bg-accent text-accent-foreground")}>{item.label}</Link>
+            ))}
+          </div>
+        </aside>
+        <section className="col-span-1 lg:col-span-9">
+          {children}
+        </section>
+      </main>
+    </div>
+  );
+}
+

--- a/forum-ui/src/components/theme-provider.tsx
+++ b/forum-ui/src/components/theme-provider.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import * as React from "react";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export function ThemeProvider({ children, ...props }: React.ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}
+

--- a/forum-ui/src/components/thread-list.tsx
+++ b/forum-ui/src/components/thread-list.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+import { MessageSquare, ThumbsUp } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const mockThreads = Array.from({ length: 8 }).map((_, i) => ({
+  id: i + 1,
+  title: `這是第 ${i + 1} 則討論串標題`,
+  author: "使用者",
+  replies: Math.floor(Math.random() * 80),
+  likes: Math.floor(Math.random() * 300),
+  category: ["閒聊", "技術", "公告"][i % 3],
+  href: `/threads/${i + 1}`
+}));
+
+export function ThreadList() {
+  return (
+    <div className="grid gap-4">
+      {mockThreads.map((t) => (
+        <Card key={t.id} className="hover:border-primary/40 transition-colors">
+          <CardHeader className="p-4">
+            <CardTitle className="text-base">
+              <Link href={t.href} className="hover:underline">{t.title}</Link>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-4 pt-0 text-sm text-muted-foreground flex items-center gap-4">
+            <span>{t.category}</span>
+            <span>by {t.author}</span>
+            <span className="ml-auto flex items-center gap-1"><MessageSquare className="h-4 w-4" /> {t.replies}</span>
+            <span className="flex items-center gap-1"><ThumbsUp className="h-4 w-4" /> {t.likes}</span>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+

--- a/forum-ui/src/components/ui/avatar.tsx
+++ b/forum-ui/src/components/ui/avatar.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
+import { cn } from "@/lib/utils";
+
+const Avatar = React.forwardRef<React.ElementRef<typeof AvatarPrimitive.Root>, React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>>(
+  ({ className, ...props }, ref) => (
+    <AvatarPrimitive.Root ref={ref} className={cn("relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full", className)} {...props} />
+  )
+);
+Avatar.displayName = AvatarPrimitive.Root.displayName;
+
+const AvatarImage = React.forwardRef<React.ElementRef<typeof AvatarPrimitive.Image>, React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>>(
+  ({ className, ...props }, ref) => (
+    <AvatarPrimitive.Image ref={ref} className={cn("aspect-square h-full w-full", className)} {...props} />
+  )
+);
+AvatarImage.displayName = AvatarPrimitive.Image.displayName;
+
+const AvatarFallback = React.forwardRef<React.ElementRef<typeof AvatarPrimitive.Fallback>, React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>>(
+  ({ className, ...props }, ref) => (
+    <AvatarPrimitive.Fallback ref={ref} className={cn("flex h-full w-full items-center justify-center rounded-full bg-muted", className)} {...props} />
+  )
+);
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
+
+export { Avatar, AvatarImage, AvatarFallback };
+

--- a/forum-ui/src/components/ui/button.tsx
+++ b/forum-ui/src/components/ui/button.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline"
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10"
+      }
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default"
+    }
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };
+

--- a/forum-ui/src/components/ui/card.tsx
+++ b/forum-ui/src/components/ui/card.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)} {...props} />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+  )
+);
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn("text-2xl font-semibold leading-none tracking-tight", className)} {...props} />
+  )
+);
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  )
+);
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  )
+);
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+  )
+);
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };
+

--- a/forum-ui/src/components/ui/input.tsx
+++ b/forum-ui/src/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+        ,
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Input.displayName = "Input";
+
+export { Input };
+

--- a/forum-ui/src/components/ui/separator.tsx
+++ b/forum-ui/src/components/ui/separator.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
+import { cn } from "@/lib/utils";
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(({ className, orientation = "horizontal", decorative = true, ...props }, ref) => (
+  <SeparatorPrimitive.Root
+    ref={ref}
+    decorative={decorative}
+    orientation={orientation}
+    className={cn(
+      "shrink-0 bg-border",
+      orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+      className
+    )}
+    {...props}
+  />
+));
+Separator.displayName = SeparatorPrimitive.Root.displayName;
+
+export { Separator };
+

--- a/forum-ui/src/components/ui/skeleton.tsx
+++ b/forum-ui/src/components/ui/skeleton.tsx
@@ -1,0 +1,10 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn("animate-pulse rounded-md bg-muted", className)} {...props} />
+  );
+}
+
+export { Skeleton };
+

--- a/forum-ui/src/lib/utils.ts
+++ b/forum-ui/src/lib/utils.ts
@@ -1,0 +1,7 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+

--- a/forum-ui/tailwind.config.ts
+++ b/forum-ui/tailwind.config.ts
@@ -1,0 +1,77 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}"
+  ],
+  theme: {
+    container: {
+      center: true,
+      padding: "2rem",
+      screens: { "2xl": "1400px" }
+    },
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))"
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))"
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))"
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))"
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))"
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))"
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))"
+        }
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)"
+      },
+      keyframes: {
+        "accordion-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-accordion-content-height)" }
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" }
+        }
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out"
+      }
+    }
+  },
+  plugins: [require("tailwindcss-animate"), require("@tailwindcss/typography")]
+};
+
+export default config;
+

--- a/forum-ui/tsconfig.json
+++ b/forum-ui/tsconfig.json
@@ -1,0 +1,44 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "types": [
+      "node"
+    ],
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
Implement a new forum UI using Next.js, Tailwind CSS, and shadcn/ui to modernize all forum pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-8fbbb207-d932-45e0-9429-320ac155d383">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8fbbb207-d932-45e0-9429-320ac155d383">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

